### PR TITLE
Add Ecsact to FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The current list includes both open and closed source ECS implementations, and e
 - [Artemis](https://github.com/junkdog/artemis-odb) (Java, custom license)
 - [Bevy ECS](https://github.com/bevyengine/bevy) (Rust, MIT)
 - [Dominion](https://github.com/dominion-dev/dominion-ecs-java) (Java, MIT)
+- [Ecsact](https://ecsact.dev)(MIT)
 - [EntityX](https://github.com/alecthomas/entityx) (C++11, MIT)
 - [Entitas](https://github.com/sschmid/Entitas-CSharp) (C#, MIT)
 - [Entitas-Redux](https://github.com/jeffcampbellmakesgames/Entitas-Redux) (C#, MIT)


### PR DESCRIPTION
[Ecsact](https://ecsact.dev/) is an open-source language that is used to describe ECS. I put it in the frameworks section, however I don't think it really qualifies. I would've added a new section, but it would only have one entry. 

If you'd be willing to include Ecsact, do you have a preference for how it's added?