### PR TITLE
Remove `legion` from frameworks list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ The current list includes both open and closed source ECS implementations, and e
 - [Fireblade](https://github.com/fireblade-engine/ecs) (Swift, MIT)
 - [Flecs](https://github.com/SanderMertens/flecs) (C/C++11, [C#](https://github.com/flecs-hub/flecs-cs), [Rust](https://github.com/jazzay/flecs-rs), [Zig](https://github.com/prime31/zig-flecs), [Lua](https://github.com/flecs-hub/flecs-lua), MIT)
 - [Hecs](https://github.com/Ralith/hecs) (Rust, Apache/MIT)
-- [Legion](https://github.com/amethyst/legion) (Rust, MIT)
 - [LeoECS](https://github.com/Leopotam/ecs) (C#, MIT)
 - [Mach ECS](https://github.com/hexops/mach) (Zig, MIT, Apache)
 - [Nu](https://github.com/bryanedds/Nu) (F#, MIT)


### PR DESCRIPTION
`legion` is no longer being actively developed, with the last update being in 2021. See https://github.com/amethyst/legion/issues/296. Additionally, discussion on the Amethyst discord indicates that the library is no longer supported, with active development ceasing on it along with the [entire Amethyst project](https://amethyst.rs/posts/amethyst--starting-fresh).