### PR TITLE
Moved Friflo ECS to its own repo - before the ECS was a sub project o…

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The current list includes both open and closed source ECS implementations, and e
 - [Fireblade](https://github.com/fireblade-engine/ecs) (Swift, MIT)
 - [Flecs](https://github.com/SanderMertens/flecs) (C/C++11, [C#](https://github.com/flecs-hub/flecs-cs), [Rust](https://github.com/jazzay/flecs-rs), [Zig](https://github.com/prime31/zig-flecs), [Lua](https://github.com/flecs-hub/flecs-lua), MIT)
 - [Fleks](https://github.com/Quillraven/Fleks) (Kotlin Multiplatform, MIT)
-- [Friflo.Engine.ECS](https://github.com/friflo/Friflo.Json.Fliox/blob/main/Engine/README.md) (C#, LGPL)
+- [Friflo ECS](https://github.com/friflo/Friflo.Engine.ECS) (C#, MIT)
 - [Hecs](https://github.com/Ralith/hecs) (Rust, Apache/MIT)
 - [LeoEcsLite](https://github.com/Leopotam/ecslite) (C#, MIT)
 - [Mach ECS](https://github.com/hexops/mach) (Zig, MIT, Apache)


### PR DESCRIPTION
Moved Friflo ECS to its own repo - before the ECS was a sub project of an ORM repository. Changed license to MIT.