### PR TITLE
Replace Arche by its successor Ark

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The current list includes both open and closed source ECS implementations, and e
 
 - [AFRAME](https://aframe.io) (HTML5/JS, MIT)
 - [Arch](https://github.com/genaray/Arch) (C#, Apache)
-- [Arche](https://github.com/mlange-42/arche) (Go, MIT)
+- [Ark](https://github.com/mlange-42/ark) (Go, Apache/MIT)
 - [Bang](https://github.com/isadorasophia/bang) (C#, MIT)
 - [Bevy ECS](https://github.com/bevyengine/bevy) (Rust, MIT)
 - [Dominion](https://github.com/dominion-dev/dominion-ecs-java) (Java, MIT)


### PR DESCRIPTION
[Ark](https://github.com/mlange-42/ark) is the official successor of [Arche](https://github.com/mlange-42/ark). It is feature-complete now, has decent test coverage, and several users of Arche already migrated their projects to Ark without any problems. So I (the author of both) think it is time now to replace Arche here.